### PR TITLE
Correct server def in haproxy.cfg for the server docker-compose creates

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -27,4 +27,4 @@ backend awx_web
     option http-pretend-keepalive
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server awx_web_1 awx_web_1:8052 check
+    server awx_haproxy_web_1 awx_haproxy_web_1:8052 check


### PR DESCRIPTION
Fix for

[ALERT] 024/181547 (7) : parsing [/usr/local/etc/haproxy/haproxy.cfg:30] : 'server awx_web_1' : invalid address: 'awx_web_1' in 'awx_web_1:8052'